### PR TITLE
Streamline multiple strategies

### DIFF
--- a/trader/gemini_bot.py
+++ b/trader/gemini_bot.py
@@ -2,11 +2,25 @@ import asyncio
 import logging
 from trader.database import init_db, get_engine, get_session, get_strategy_by_name
 from trader.gemini.client import GeminiClient
-from trader.models import StrategyState
-from trader.strategies import StrategyManager, StrategyType
+from trader.models import StrategyState, StrategyType
+from trader.strategies import StrategyManager
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+async def update_or_create_strategy(manager: StrategyManager, strategy_data: dict) -> None:
+    """Update existing strategy or create new one"""
+    try:
+        strategy_name = strategy_data["name"]
+        logger.info(f"Processing strategy: {strategy_name}")
+        
+        # Update or create strategy
+        strategy = await manager.create_strategy(strategy_data)
+        logger.info(f"Strategy {strategy_name} {'updated' if strategy else 'created'}")
+        
+    except Exception as e:
+        logger.error(f"Error processing strategy {strategy_data['name']}: {str(e)}")
+        raise
 
 async def main():
     # Initialize database and clients
@@ -18,41 +32,43 @@ async def main():
     # Initialize strategy manager
     manager = StrategyManager(session, client)
     
-    # Update breakout strategy
-    breakout_strategy = {
-        "name": "DOGE Breakout $0.40",
-        "type": StrategyType.BREAKOUT,
-        "symbol": "dogeusd",
-        "state": StrategyState.ACTIVE,
-        "check_interval": 3,
-        "config": {
-            "breakout_price": "0.40000",
-            "amount": "1250",
-            "take_profit_1": "0.42500",  # Expected profit: 6.25% ($31.25)
-            "take_profit_2": "0.44000",  # Expected profit: 10% ($50.00)
-            "stop_loss": "0.41000"       # Expected loss: 2.5% ($12.50)
+    # Define strategies
+    strategies = [
+        # Breakout strategy
+        {
+            "name": "DOGE Breakout $0.40",
+            "type": StrategyType.BREAKOUT,
+            "symbol": "dogeusd",
+            "state": StrategyState.ACTIVE,
+            "check_interval": 3,
+            "config": {
+                "breakout_price": "0.40000",
+                "amount": "1250",
+                "take_profit_1": "0.42500",  # Expected profit: 6.25% ($31.25)
+                "take_profit_2": "0.44000",  # Expected profit: 10% ($50.00)
+                "stop_loss": "0.41000"       # Expected loss: 2.5% ($12.50)
+            }
+        },
+        # Range strategy
+        {
+            "name": "DOGE Range 0.385-0.398",
+            "type": StrategyType.RANGE,
+            "symbol": "dogeusd",
+            "state": StrategyState.ACTIVE,
+            "check_interval": 3,
+            "config": {
+                "support_price": "0.38500",   # Expected buy price
+                "resistance_price": "0.39800",  # Expected sell price, profit: 3.38% ($51.80)
+                "stop_loss_price": "0.38200",   # Expected loss: 0.78% ($12.00)
+                "amount": "4000"
+            }
         }
-    }
-    
-    # Update range strategy
-    range_strategy = {
-        "name": "DOGE Range 0.385-0.398",
-        "type": StrategyType.RANGE,
-        "symbol": "dogeusd",
-        "state": StrategyState.ACTIVE,
-        "check_interval": 3,
-        "config": {
-            "support_price": "0.38500",   # Expected buy price
-            "resistance_price": "0.39800",  # Expected sell price, profit: 3.38% ($51.80)
-            "stop_loss_price": "0.38200",   # Expected loss: 0.78% ($12.00)
-            "amount": "4000"
-        }
-    }
+    ]
     
     try:
-        # Update both strategies with new orders if config changed
-        await manager.update_strategy_orders(breakout_strategy)
-        await manager.update_strategy_orders(range_strategy)
+        # Process each strategy
+        for strategy_data in strategies:
+            await update_or_create_strategy(manager, strategy_data)
         
         logger.info("Starting strategy monitor...")
         # Start monitoring - this will run indefinitely

--- a/trader/gemini_bot.py
+++ b/trader/gemini_bot.py
@@ -2,9 +2,9 @@ import asyncio
 import logging
 from trader.database import init_db, get_engine, get_session, get_strategy_by_name
 from trader.gemini.client import GeminiClient
-from trader.models import StrategyState, StrategyType, Status
+from trader.models import StrategyState, StrategyType
 from trader.strategies import StrategyManager
-from sqlalchemy import select
+from sqlmodel import select
 from trader.models import TradingStrategy
 
 logging.basicConfig(level=logging.INFO)
@@ -25,7 +25,7 @@ async def deactivate_removed_strategies(manager: StrategyManager, session, curre
                 
                 # Update strategy status
                 strategy.is_active = False
-                strategy.status = Status.CANCELLED
+                strategy.state = StrategyState.CANCELED
                 session.add(strategy)
                 
         session.commit()
@@ -62,16 +62,16 @@ async def main():
     strategies = [
         # Range strategy
         {
-            "name": "DOGE Range 0.408-0.420 (Position 1)",
+            "name": "DOGE Range 0.408-0.420 (Position 2)", 
             "type": StrategyType.RANGE,
             "symbol": "dogeusd",
             "state": StrategyState.ACTIVE,
             "check_interval": 3,
             "config": {
-                "support_price": "0.40800",
-                "resistance_price": "0.42000",
-                "stop_loss_price": "0.40400",
-                "amount": "5000"              # First 5000 DOGE position
+                "support_price": "0.40800",   # Buy price: $4,080.00 position cost
+                "resistance_price": "0.42000", # Sell price for +2.94% profit ($120 on 10000 DOGE)
+                "stop_loss_price": "0.40400", # Stop loss for -0.98% loss ($40 on 10000 DOGE)
+                "amount": "10000"             # 10000 DOGE position (~$4,080 capital use)
             }
         }
     ]


### PR DESCRIPTION
# Enhance strategy lifecycle management in Gemini bot

## Changes Made
- **Strategy Deactivation**:
  - Implemented `deactivate_removed_strategies` to disable strategies no longer defined in the configuration.
  - Updated database entries for deactivated strategies, marking them as `CANCELED`.
- **Strategy Update/Create**:
  - Introduced `update_or_create_strategy` to handle updates for existing strategies or creation of new ones.
  - Added detailed logging for strategy processing.
- **Refactored `main`**:
  - Centralized strategy definition into a list for better management.
  - Automated deactivation of obsolete strategies and updating/creating active ones.
- **Improved Logging**:
  - Added logs for strategy activation, deactivation, and error handling.
  - Enhanced visibility into strategy configurations and lifecycle changes.
